### PR TITLE
Change coverage checker to lcov

### DIFF
--- a/.github/workflows/build-test-coverage-any.yaml
+++ b/.github/workflows/build-test-coverage-any.yaml
@@ -83,13 +83,13 @@ jobs:
       - name: Coverage
         working-directory: ${{github.workspace}}/build
         shell: bash
-        run: make coverage_xml
+        run: make coverage
 
         # Upload coverage results to Codecov
       - uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ${{github.workspace}}/build/coverage_xml.xml
+          files: ${{github.workspace}}/build/coverage.info
           flags: unittests # optional
           fail_ci_if_error: false
           verbose: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,10 +162,10 @@ if(BUILD_TESTING)
         # The ctest_no_fail.sh is used because the coverage tests won't
         # continue if the ctest returns non zero. Ctest will returns 0 only if
         # all tests pass.
-        setup_target_for_coverage_gcovr_html(
+        setup_target_for_coverage_lcov(
             NAME coverage
             EXECUTABLE ${CMAKE_CURRENT_LIST_DIR}/script/ctest_no_fail.sh
-            EXCLUDE "thirdparty/*"
+            EXCLUDE "thirdparty/*" "include/*" "test/*"
             DEPENDENCIES test_chromosome test_genome test_genomic_location test_replication_fork test_fork_manager test_data_manager test_util
         )
         setup_target_for_coverage_gcovr_xml(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,7 +157,6 @@ if(BUILD_TESTING)
 
         include(CodeCoverage)
         APPEND_COVERAGE_COMPILER_FLAGS()
-        set(COVERAGE_GCOVR_EXCLUDES "thirdparty/*" "include/*" "test/*")
 
         # The ctest_no_fail.sh is used because the coverage tests won't
         # continue if the ctest returns non zero. Ctest will returns 0 only if
@@ -166,12 +165,6 @@ if(BUILD_TESTING)
             NAME coverage
             EXECUTABLE ${CMAKE_CURRENT_LIST_DIR}/script/ctest_no_fail.sh
             EXCLUDE "thirdparty/*" "include/*" "test/*"
-            DEPENDENCIES test_chromosome test_genome test_genomic_location test_replication_fork test_fork_manager test_data_manager test_util
-        )
-        setup_target_for_coverage_gcovr_xml(
-            NAME coverage_xml
-            EXECUTABLE ${CMAKE_CURRENT_LIST_DIR}/script/ctest_no_fail.sh
-            EXCLUDE "thirdparty/*"
             DEPENDENCIES test_chromosome test_genome test_genomic_location test_replication_fork test_fork_manager test_data_manager test_util
         )
     endif()


### PR DESCRIPTION
That is te coverage tool suggested by Codecov. This change comes from the divergences with previous tool (gcovr) between hit report locally generated and the one reported in codecov.