### PR TITLE
Fix parsing of config file containing an `evolution` key

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,6 +131,7 @@ if(BUILD_TESTING)
     add_executable(test_data_manager test/test_data_manager.cpp)
     add_executable(test_util test/test_util.cpp)
     add_executable(test_configuration test/test_configuration.cpp)
+    add_executable(test_evolution test/test_evolution.cpp)
 
     target_link_libraries(simulator deps gtest)
 
@@ -142,6 +143,7 @@ if(BUILD_TESTING)
     target_link_libraries(test_data_manager deps gtest SQLiteCpp libzstd_static sqlite3 pthread dl gcov)
     target_link_libraries(test_util deps gtest gmock gcov)
     target_link_libraries(test_configuration deps ryml gtest gcov)
+    target_link_libraries(test_evolution deps SQLiteCpp sqlite3 dl ryml gtest gmock gcov)
 
     gtest_discover_tests(test_chromosome)
     gtest_discover_tests(test_genome)
@@ -151,6 +153,7 @@ if(BUILD_TESTING)
     gtest_discover_tests(test_data_manager)
     gtest_discover_tests(test_util)
     gtest_discover_tests(test_configuration)
+    gtest_discover_tests(test_evolution)
 
     #######
     # Coverage report
@@ -168,7 +171,7 @@ if(BUILD_TESTING)
             NAME coverage
             EXECUTABLE ${CMAKE_CURRENT_LIST_DIR}/script/ctest_no_fail.sh
             EXCLUDE "thirdparty/*" "include/*" "test/*"
-            DEPENDENCIES test_chromosome test_genome test_genomic_location test_replication_fork test_fork_manager test_data_manager test_util test_configuration
+            DEPENDENCIES test_chromosome test_genome test_genomic_location test_replication_fork test_fork_manager test_data_manager test_util test_configuration test_evolution
         )
     endif()
 endif()

--- a/include/configuration.hpp
+++ b/include/configuration.hpp
@@ -19,7 +19,7 @@
             return path.substr(path.rfind(".") + 1, path.size());              \
         })(),                                                                  \
             [](cl_configuration_data &data, std::string val,                   \
-               ryml::NodeRef base) -> void { data.field = std::stoull(val); }  \
+               ryml::NodeRef &base) -> void { data.field = std::stoull(val); } \
     }
 #define PUSH_D(field)                                                          \
     {                                                                          \
@@ -28,7 +28,7 @@
             return path.substr(path.rfind(".") + 1, path.size());              \
         })(),                                                                  \
             [](cl_configuration_data &data, std::string val,                   \
-               ryml::NodeRef base) -> void { data.field = std::stod(val); }    \
+               ryml::NodeRef &base) -> void { data.field = std::stod(val); }   \
     }
 #define PUSH_STR(field)                                                        \
     {                                                                          \
@@ -37,7 +37,7 @@
             return path.substr(path.rfind(".") + 1, path.size());              \
         })(),                                                                  \
             [](cl_configuration_data &data, std::string val,                   \
-               ryml::NodeRef base) -> void { data.field = std::string(val); }  \
+               ryml::NodeRef &base) -> void { data.field = std::string(val); } \
     }
 #define PUSH_BOOL(field)                                                       \
     {                                                                          \
@@ -46,7 +46,7 @@
             return path.substr(path.rfind(".") + 1, path.size());              \
         })(),                                                                  \
             [](cl_configuration_data &data, std::string val,                   \
-               ryml::NodeRef base) {                                           \
+               ryml::NodeRef &base) {                                          \
                 data.field = !std::string(val).compare("true");                \
             }                                                                  \
     }
@@ -58,12 +58,19 @@
             return path.substr(path.rfind(".") + 1, path.size());              \
         })(),                                                                  \
             [](cl_configuration_data &data, std::string val,                   \
-               ryml::NodeRef base) {                                           \
+               ryml::NodeRef &base) {                                          \
                 std::string path = #field;                                     \
                 c4::csubstr k    = c4::to_csubstr(                             \
-                    path.substr(path.rfind(".") + 1, path.size()));         \
+                    path.substr(path.rfind(".") + 1, path.size()).c_str());    \
                 conf_function_map map = functions;                             \
-                read_conf_yml(base[k], data, map);                             \
+                for (ryml::NodeRef c : base.children())                        \
+                {                                                              \
+                    if (!c.key().compare(k))                                   \
+                    {                                                          \
+                        read_conf_yml(c, data, map);                           \
+                        break;                                                 \
+                    }                                                          \
+                }                                                              \
             }                                                                  \
     }
 
@@ -167,11 +174,11 @@ bool operator==(const cl_configuration_data &a, const cl_configuration_data &b);
 
 typedef std::unordered_map<
     std::string,
-    std::function<void(cl_configuration_data &, std::string, ryml::NodeRef)>>
+    std::function<void(cl_configuration_data &, std::string, ryml::NodeRef &)>>
     conf_function_map;
 
 void read_conf_yml(
-    ryml::NodeRef base, cl_configuration_data &arguments,
+    ryml::NodeRef &base, cl_configuration_data &arguments,
     conf_function_map &function_map,
     std::function<void(std::string)> on_unknown = [](std::string argument) {
         throw std::invalid_argument(

--- a/include/configuration.hpp
+++ b/include/configuration.hpp
@@ -173,12 +173,10 @@ typedef std::unordered_map<
 void read_conf_yml(
     ryml::NodeRef base, cl_configuration_data &arguments,
     conf_function_map &function_map,
-    std::function<void(std::string)> on_unknown =
-        [](std::string argument) {
-            throw std::invalid_argument(
-                "Unknown parameter in configuration file: " + argument);
-        }
-);
+    std::function<void(std::string)> on_unknown = [](std::string argument) {
+        throw std::invalid_argument(
+            "Unknown parameter in configuration file: " + argument);
+    });
 
 /*! This class represents a running configuration for the simulations.
  *
@@ -188,6 +186,9 @@ void read_conf_yml(
 class Configuration
 {
   private:
+    // Allow the test class to set args directly
+    friend class EvolutionTest;
+
     cl_configuration_data args;
 
     cl_configuration_data configure_cmd_options(int argc, char *argv[]);

--- a/include/evolution.hpp
+++ b/include/evolution.hpp
@@ -14,7 +14,10 @@
 
 class EvolutionManager
 {
-  private:
+  protected:
+    // This allows us to test private methods and attributes.
+    friend class EvolutionTest;
+
     int seed;
     std::mt19937 rand_generator;
     Configuration &configuration;
@@ -26,17 +29,26 @@ class EvolutionManager
 
     int current_generation = 0;
 
-    void simulate();
-    void reproduce();
+    virtual void simulate();
+    virtual void reproduce();
 
   public:
     EvolutionManager(Configuration &configuration, int seed);
     ~EvolutionManager();
 
     void run_all();
-    void generation();
+    virtual void generation();
 
-    void snapshot(std::string folder);
+    virtual void snapshot(std::string folder);
 };
+
+typedef struct
+{
+    double collisions = 0;
+    double time       = 0;
+} instance_metrics;
+
+double calculate_fitness(instance_metrics metrics,
+                         cl_evolution_data config_data);
 
 #endif

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -81,7 +81,8 @@ void read_conf_yml(ryml::NodeRef base, cl_configuration_data &arguments,
         auto val = std::string();
 
         c4::from_chars(ref.key(), &key);
-        c4::from_chars(ref.val(), &val);
+       // c4::from_chars(ref.val(), &val);
+        std::cout << key << " " << val << std::endl;
 
         // Call callback on unknown
         if (function_map.find(key) == function_map.end())
@@ -276,6 +277,7 @@ Configuration::read_configuration_file(std::string filename,
 
     ryml::NodeRef simulation = tree["simulation"];
     ryml::NodeRef parameters = tree["parameters"];
+
 
     std::string mode = std::string();
     c4::from_chars(simulation.val(), &mode);

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -71,7 +71,7 @@ conf_function_map cl_configuration_functions = {
     PUSH_D(probability),    PUSH_STR(output),
     PUSH_ULL(threads),      PUSH_FUNCS(evolution, cl_evolution_functions)};
 
-void read_conf_yml(ryml::NodeRef base, cl_configuration_data &arguments,
+void read_conf_yml(ryml::NodeRef &base, cl_configuration_data &arguments,
                    conf_function_map &function_map,
                    std::function<void(std::string)> on_unknown)
 {
@@ -81,8 +81,7 @@ void read_conf_yml(ryml::NodeRef base, cl_configuration_data &arguments,
         auto val = std::string();
 
         c4::from_chars(ref.key(), &key);
-       // c4::from_chars(ref.val(), &val);
-        std::cout << key << " " << val << std::endl;
+        if (ref.has_val()) c4::from_chars(ref.val(), &val);
 
         // Call callback on unknown
         if (function_map.find(key) == function_map.end())
@@ -185,12 +184,11 @@ cl_configuration_data Configuration::configure_cmd_options(int argc,
     }
     if (config.length() > 0) read_configuration_file(config, arguments);
 
-    if (dormant>=0)
-        arguments.dormant = !!dormant;
+    if (dormant >= 0) arguments.dormant = !!dormant;
 
     if (!arguments.cells)
     {
-       throw std::invalid_argument("Argument \"cells\" (c) is mandatory!");
+        throw std::invalid_argument("Argument \"cells\" (c) is mandatory!");
     }
 
     if (!arguments.organism.length())
@@ -277,7 +275,6 @@ Configuration::read_configuration_file(std::string filename,
 
     ryml::NodeRef simulation = tree["simulation"];
     ryml::NodeRef parameters = tree["parameters"];
-
 
     std::string mode = std::string();
     c4::from_chars(simulation.val(), &mode);

--- a/src/evolution.cpp
+++ b/src/evolution.cpp
@@ -114,15 +114,15 @@ void EvolutionManager::reproduce()
     int to_kill =
         arguments.evolution.population - arguments.evolution.survivors;
 
-    int reproduced = 0;
+    int killed = 0;
 
-    while (reproduced < to_kill)
+    while (killed < to_kill)
     {
-        auto to_kill = killing_roulette(rand_generator);
-        if (!data_providers[to_kill]->isdead()) // Check if organism is not dead
+        auto kill_index = killing_roulette(rand_generator);
+        if (!data_providers[kill_index]->isdead()) // Check if organism is not dead
         {
-            data_providers[to_kill]->die();
-            reproduced++;
+            data_providers[kill_index]->die();
+            killed++;
         }
     }
 

--- a/src/evolution.cpp
+++ b/src/evolution.cpp
@@ -8,12 +8,6 @@
 
 #include "evolution.hpp"
 
-typedef struct
-{
-    double collisions = 0;
-    double time       = 0;
-} instance_metrics;
-
 double calculate_fitness(instance_metrics metrics,
                          cl_evolution_data config_data)
 {

--- a/test/config/config_evolution.yaml
+++ b/test/config/config_evolution.yaml
@@ -1,6 +1,7 @@
 simulation: evolution
 parameters:
   # Basic simulation data
+  name: abc
   cells: 1
   organism: TcruziCLBrenerEsmeraldo-like
   resources: 50
@@ -26,8 +27,8 @@ parameters:
           max: 1000
       genes:
         move:
-          std: 50
           prob: 0.5
+          std: 50
         swap:
           prob: 0.3
     fitness: # Fitness calculation

--- a/test/config/config_evolution.yaml
+++ b/test/config/config_evolution.yaml
@@ -1,0 +1,43 @@
+simulation: evolution
+parameters:
+  # Basic simulation data
+  cells: 1
+  organism: TcruziCLBrenerEsmeraldo-like
+  resources: 50
+  speed: 65
+  period: 1000
+  timeout: 100000
+  dormant: true
+
+  evolution: # Evolution simulator data
+    population: 5
+    generations: 50
+    survivors: 13
+    mutations: # Allowed mutation types and their parameters
+      probability_landscape:
+        add: 0.15           # 15% chance of adding a new source
+        del: 0.1            # 10% chance of adding a new source
+        change_mean:
+          prob: 0.05   # 5% chance of changing mean for each source
+          std: 2000
+        change_std:
+          prob: 0.05    # 5% chance of changing standard variation for each source
+          std: 50
+          max: 1000
+      genes:
+        move:
+          std: 50
+          prob: 0.5
+        swap:
+          prob: 0.3
+    fitness: # Fitness calculation
+      min_sphase: 1
+      match_mfaseq: 0
+      max_coll_all: 0
+      min_coll_all: 0
+      max_coll:
+        gene: "a"
+        weight: 0
+      min_coll:
+        gene: "a"
+        weight: 0

--- a/test/config/config_evolution.yaml
+++ b/test/config/config_evolution.yaml
@@ -11,9 +11,9 @@ parameters:
   dormant: true
 
   evolution: # Evolution simulator data
-    population: 5
-    generations: 50
-    survivors: 13
+    population: 2
+    generations: 2
+    survivors: 1
     mutations: # Allowed mutation types and their parameters
       probability_landscape:
         add: 0.15           # 15% chance of adding a new source

--- a/test/test_configuration.cpp
+++ b/test/test_configuration.cpp
@@ -210,9 +210,9 @@ TEST_F(ConfigurationTest, ValidEvolutionConfigFile)
     expected.dormant                                       = true;
     expected.name                                          = "abc";
     expected.period                                        = 1000;
-    expected.evolution.population                          = 5;
-    expected.evolution.generations                         = 50;
-    expected.evolution.survivors                           = 13;
+    expected.evolution.population                          = 2;
+    expected.evolution.generations                         = 2;
+    expected.evolution.survivors                           = 1;
     expected.evolution.mutations.probability_landscape.add = 0.15;
     expected.evolution.mutations.probability_landscape.del = 0.1;
     expected.evolution.mutations.probability_landscape.change_mean.prob = 0.05;

--- a/test/test_configuration.cpp
+++ b/test/test_configuration.cpp
@@ -198,6 +198,54 @@ TEST_F(ConfigurationTest, InvalidBasicConfigFileOption)
                  std::invalid_argument);
 }
 
+TEST_F(ConfigurationTest, ValidEvolutionConfigFile)
+{
+    cl_configuration_data expected;
+    expected.mode                                          = "evolution";
+    expected.cells                                         = 1;
+    expected.organism                                      = "dummy";
+    expected.resources                                     = 2;
+    expected.speed                                         = 3;
+    expected.timeout                                       = 5;
+    expected.dormant                                       = true;
+    expected.seed                                          = 4;
+    expected.name                                          = "abc";
+    expected.period                                        = 6;
+    expected.constitutive                                  = 7;
+    expected.data_dir                                      = "data_dir/";
+    expected.probability                                   = 8;
+    expected.output                                        = "out_folder/";
+    expected.threads                                       = 9;
+    expected.evolution.population                          = 5;
+    expected.evolution.generations                         = 50;
+    expected.evolution.survivors                           = 13;
+    expected.evolution.mutations.probability_landscape.add = 0.15;
+    expected.evolution.mutations.probability_landscape.del = 0.1;
+    expected.evolution.mutations.probability_landscape.change_mean.prob = 0.05;
+    expected.evolution.mutations.probability_landscape.change_mean.std  = 2000;
+    expected.evolution.mutations.probability_landscape.change_std.prob  = 0.05;
+    expected.evolution.mutations.probability_landscape.change_std.std   = 50;
+    expected.evolution.mutations.probability_landscape.change_std.max   = 1000;
+    expected.evolution.mutations.genes.move.prob                        = 0.5;
+    expected.evolution.mutations.genes.move.std                         = 50;
+    expected.evolution.mutations.genes.swap.prob                        = 0.3;
+    expected.evolution.fitness.min_sphase                               = 1;
+    expected.evolution.fitness.match_mfaseq                             = 0;
+    expected.evolution.fitness.max_coll_all                             = 0;
+    expected.evolution.fitness.min_coll_all                             = 0;
+    expected.evolution.fitness.max_coll.weight                          = 0;
+    expected.evolution.fitness.max_coll.gene                            = "";
+    expected.evolution.fitness.min_coll.weight                          = 0;
+    expected.evolution.fitness.min_coll.gene                            = "";
+
+    std::vector<char *> argv_config = {
+        "program_name", "-C", "../test/config/config_evolution.yaml"};
+    optind = 1;
+    cl_configuration_data result;
+    result = Configuration(argv_config.size(), argv_config.data()).arguments();
+    ASSERT_EQ(expected, result);
+}
+
 int main(int argc, char **argv)
 {
     ::testing::InitGoogleTest(&argc, argv);

--- a/test/test_configuration.cpp
+++ b/test/test_configuration.cpp
@@ -19,7 +19,7 @@ class ConfigurationTest : public ::testing::Test
 
 std::vector<char *> argv_mock()
 {
-    std::vector<char *> argv_mock = {
+    std::vector<const char *> argv_mock = {
         "program_name",
         "--gpu",
         "false",
@@ -54,7 +54,7 @@ std::vector<char *> argv_mock()
     };
 
     std::vector<char *> argv_non_const;
-    for (char *a : argv_mock)
+    for (const char *a : argv_mock)
     {
         char *b = (char *)malloc(strlen(a) * sizeof(char));
         for (int i = 0; i < strlen(a); i++)
@@ -203,19 +203,13 @@ TEST_F(ConfigurationTest, ValidEvolutionConfigFile)
     cl_configuration_data expected;
     expected.mode                                          = "evolution";
     expected.cells                                         = 1;
-    expected.organism                                      = "dummy";
-    expected.resources                                     = 2;
-    expected.speed                                         = 3;
-    expected.timeout                                       = 5;
+    expected.organism                                      = "TcruziCLBrenerEsmeraldo-like";
+    expected.resources                                     = 50;
+    expected.speed                                         = 65;
+    expected.timeout                                       = 100000;
     expected.dormant                                       = true;
-    expected.seed                                          = 4;
     expected.name                                          = "abc";
-    expected.period                                        = 6;
-    expected.constitutive                                  = 7;
-    expected.data_dir                                      = "data_dir/";
-    expected.probability                                   = 8;
-    expected.output                                        = "out_folder/";
-    expected.threads                                       = 9;
+    expected.period                                        = 1000;
     expected.evolution.population                          = 5;
     expected.evolution.generations                         = 50;
     expected.evolution.survivors                           = 13;
@@ -233,10 +227,10 @@ TEST_F(ConfigurationTest, ValidEvolutionConfigFile)
     expected.evolution.fitness.match_mfaseq                             = 0;
     expected.evolution.fitness.max_coll_all                             = 0;
     expected.evolution.fitness.min_coll_all                             = 0;
+    expected.evolution.fitness.max_coll.gene                            = "a";
     expected.evolution.fitness.max_coll.weight                          = 0;
-    expected.evolution.fitness.max_coll.gene                            = "";
+    expected.evolution.fitness.min_coll.gene                            = "a";
     expected.evolution.fitness.min_coll.weight                          = 0;
-    expected.evolution.fitness.min_coll.gene                            = "";
 
     std::vector<char *> argv_config = {
         "program_name", "-C", "../test/config/config_evolution.yaml"};

--- a/test/test_evolution.cpp
+++ b/test/test_evolution.cpp
@@ -16,6 +16,14 @@ class MockEvolutionManager : public EvolutionManager
 
     cl_configuration_data get_arguments() { return this->arguments; }
     int get_current_generation() { return this->current_generation; }
+    std::vector<std::shared_ptr<EvolutionDataProvider>> get_data_providers()
+    {
+        return this->data_providers;
+    }
+    std::vector<std::vector<simulation_stats>> get_population()
+    {
+        return this->population;
+    }
 };
 
 class EvolutionTest : public ::testing::Test
@@ -49,15 +57,25 @@ TEST_F(EvolutionTest, CalculateFitness)
 
 TEST_F(EvolutionTest, TestConstructor)
 {
-    std::vector<char *> argv_mock = {
-        "program_name", "--cells", "2",         "--organism", "dummy",
-        "--resources",  "2",       "--timeout", "5"};
+    std::vector<char *> argv_mock = {"program_name",
+                                     "--cells",
+                                     "2",
+                                     "--organism",
+                                     "dummy",
+                                     "--resources",
+                                     "2",
+                                     "--timeout",
+                                     "5",
+                                     "-C",
+                                     "../test/config/config_evolution.yaml"};
 
     // Reset getopt global variable
     optind               = 1;
     Configuration config = Configuration(argv_mock.size(), argv_mock.data());
     MockEvolutionManager evo(config, 0);
     ASSERT_EQ(evo.get_arguments(), config.arguments());
+    ASSERT_FALSE(evo.get_data_providers().empty());
+    ASSERT_FALSE(evo.get_population().empty());
 }
 
 TEST_F(EvolutionTest, TestGeneration)

--- a/test/test_evolution.cpp
+++ b/test/test_evolution.cpp
@@ -1,0 +1,72 @@
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <omp.h>
+
+#include "../include/evolution.hpp"
+class MockEvolutionManager : public EvolutionManager
+{
+  public:
+
+    MOCK_METHOD(void, simulate, (), (override));
+    MOCK_METHOD(void, reproduce, (), (override));
+
+    MockEvolutionManager(Configuration config, int seed)
+        : EvolutionManager(config, seed)
+    {
+    }
+
+    cl_configuration_data get_arguments() { return this->arguments; }
+    int get_current_generation() { return this->current_generation; }
+};
+
+class EvolutionTest : public ::testing::Test
+{
+  protected: // Runs before each test
+    // Allow the test class to set args directly
+    friend class Configuration;
+    void SetUp() { omp_set_num_threads(1); }
+};
+
+TEST_F(EvolutionTest, CalculateFitness)
+{
+    instance_metrics metrics;
+    cl_evolution_data config;
+    double fitness;
+
+    metrics.collisions          = 2000;
+    config.fitness.max_coll_all = 0.5;
+    config.fitness.min_coll_all = 0.5;
+
+    fitness = calculate_fitness(metrics, config);
+    ASSERT_NEAR(fitness, 0.5, 0.001);
+
+    metrics.collisions          = 50000;
+    config.fitness.max_coll_all = 1.0;
+    config.fitness.min_coll_all = 0.0;
+
+    fitness = calculate_fitness(metrics, config);
+    ASSERT_NEAR(fitness, 1.0, 0.001);
+}
+
+TEST_F(EvolutionTest, TestConstructor)
+{
+    std::vector<char *> argv_mock = {
+        "program_name", "--cells", "2",         "--organism",
+        "--resources",  "2",       "--timeout", "5"};
+
+    // Reset getopt global variable
+    optind               = 1;
+    Configuration config = Configuration(argv_mock.size(), argv_mock.data());
+    MockEvolutionManager evo(config, 0);
+    ASSERT_EQ(evo.get_arguments(), config.arguments());
+}
+
+TEST_F(EvolutionTest, TestGeneration) {
+
+}
+
+int main(int argc, char **argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/test/test_evolution.cpp
+++ b/test/test_evolution.cpp
@@ -6,7 +6,6 @@
 class MockEvolutionManager : public EvolutionManager
 {
   public:
-
     MOCK_METHOD(void, simulate, (), (override));
     MOCK_METHOD(void, reproduce, (), (override));
 
@@ -51,7 +50,7 @@ TEST_F(EvolutionTest, CalculateFitness)
 TEST_F(EvolutionTest, TestConstructor)
 {
     std::vector<char *> argv_mock = {
-        "program_name", "--cells", "2",         "--organism",
+        "program_name", "--cells", "2",         "--organism", "dummy",
         "--resources",  "2",       "--timeout", "5"};
 
     // Reset getopt global variable
@@ -61,8 +60,19 @@ TEST_F(EvolutionTest, TestConstructor)
     ASSERT_EQ(evo.get_arguments(), config.arguments());
 }
 
-TEST_F(EvolutionTest, TestGeneration) {
+TEST_F(EvolutionTest, TestGeneration)
+{
+    std::vector<char *> argv_mock = {
+        "program_name", "--cells", "2",         "--organism", "dummy",
+        "--resources",  "2",       "--timeout", "5"};
 
+    // Reset getopt global variable
+    optind               = 1;
+    Configuration config = Configuration(argv_mock.size(), argv_mock.data());
+    MockEvolutionManager evo(config, 0);
+    EXPECT_CALL(evo, simulate());
+    EXPECT_CALL(evo, reproduce());
+    evo.generation();
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
This PR ended up bringing more than one change.

- Add tests for some parts of the evolution file;
- Fix the parsing of configuration files that contain an `evolution` key;
- Add an example config file containing an evolution key to be used by the tests.